### PR TITLE
supply arguments which are used as global variables in functions in t…

### DIFF
--- a/tools/analyze_phonons.py
+++ b/tools/analyze_phonons.py
@@ -21,61 +21,38 @@ import os
 import optparse
 import subprocess
 
-parser = optparse.OptionParser()
-parser.add_option('--temp', help="target temperature to analyze")
-parser.add_option('--mode', help="specify phonon mode index to print")
-parser.add_option('--kpoint', help="specify k-point index to print")
-
-parser.add_option('--calc', metavar='tau|kappa|cumulative|cumulative2|kappa_boundary',
-                  help=('specify what to print. Available options are '
-                        'tau (Lifetime, mean-free-path, etc.), '
-                        'kappa (Thermal conductivity), '
-                        'cumulative (Cumulative thermal conductivity), '
-                        'cumulative2 (Cumulative thermal conductivity with specific xyz-directions), '
-                        'and kappa_boundary (Thermal conductivity with boundary effect). '
-                        'When --calc=cumulative2, please specify the '
-                        '--direction option. When --calc=kappa_boundary, '
-                        'please specify the --size option.'))
-
-parser.add_option('--isotope', metavar="PREFIX.self_isotope",
-                  help="specify the file PREFIX.self_isotope to include the \
-effect of phonon-isotope scatterings. When given, the phonon scattering rates will be \
-updated as 1/tau_{new} = 1/tau_{phonon-phonon} + 1/tau_{phonon-isotope}. \
-The PREFIX.self_isotope can be generated using 'anphon' with ISOTOPE=2 option.")
-
-parser.add_option('--noavg', action="store_false", dest="average_gamma",
-                  default=True, help="do not average the damping function \
-at degenerate points")
-
-parser.add_option('--size', help="specify the grain boundary size in units of \
-nm. The default value is 1000 nm.")
-
-parser.add_option('--length', metavar="Lmax:dL",
-                  help="specify the maximum value of system size L and its \
-step dL in units of nm. \
-The default value is --length=1000:10 .")
-
-group = optparse.OptionGroup(parser,
-                             "The following options are available/necessary \
-when --calc=cumulative2 ")
-
-group.add_option('--direction', metavar="1|2|3", help="specify which \
-direction (xyz) to consider the size effect. \
-When --direction=1 (2, 3), phonon mean-free-paths (ell) \
-along x (y, z) are compared with the system size L. Then, \
-the cumulative thermal conductivity is calculated by considering \
-phonon modes satisfying ell <= L.")
-
-parser.add_option_group(group)
-
-options, args = parser.parse_args()
-file_result = args[0]
-
-dir_obj = os.path.dirname(__file__)
-analyze_obj = dir_obj + "/analyze_phonons "
+_RETURN_CMD_DEFAULT = False
 
 
-def print_temperature_dep_lifetime():
+def set_average(options):
+    if options.average_gamma:
+        avg = "1"
+    else:
+        avg = "0"
+
+    if options.isotope is None:
+        isotope = "0"
+        file_isotope = "none"
+    else:
+        isotope = "1"
+        file_isotope = options.isotope
+    return avg, isotope, file_isotope
+
+
+def print_temperature_dep_lifetime(analyze_obj, calc, file_result,  options, return_cmd=_RETURN_CMD_DEFAULT):
+    """print_temperature_dep_lifetime
+
+    Args:
+        analyze_obj (str): "analyze_phonon".
+        calc (str): calculation type.
+        file_result (str): result of RTA.
+        options (_type_): analyze_phonon options
+        return_cmd (_type_, optional): execute commnd or not. Defaults to _RETURN_CMD_DEFAULT.
+
+    Returns:
+        list: command list if return_cmd=True.
+    """
+    avg, isotope, file_isotope = set_average(options)
 
     if options.kpoint is None or options.mode is None:
         sys.exit("Please specify the temperature by --temp option, \
@@ -89,14 +66,35 @@ or specify both --kpoint and --mode when --calc=tau")
         target_k = int(options.kpoint)
         target_s = int(options.mode)
         calc = "tau_temp"
-        command = analyze_obj + file_result + " " + calc + " " + avg \
-            + " " + str(target_k) + " " + str(target_s)\
-            + " " + isotope + " " + file_isotope
+        if return_cmd:
+            command = [file_result, calc, avg,
+                       str(target_k), str(target_s),
+                       isotope, file_isotope]
+            return command
 
-        subprocess.call(command, shell=True)
+        else:
+
+            command = analyze_obj + file_result + " " + calc + " " + avg \
+                + " " + str(target_k) + " " + str(target_s)\
+                + " " + isotope + " " + file_isotope
+
+            subprocess.call(command, shell=True)
 
 
-def print_lifetime_at_given_temperature():
+def print_lifetime_at_given_temperature(analyze_obj, calc, file_result, options, return_cmd=_RETURN_CMD_DEFAULT):
+    """print_lifetime_at_given_temperature
+
+    Args:
+        analyze_obj (str): "analyze_phonon".
+        calc (str): calculation type.
+        file_result (str): result of RTA.
+        options (dict): options of analyze_phonon.
+        return_cmd (_type_, optional): execute command or not. Defaults to _RETURN_CMD_DEFAULT.
+
+    Returns:
+        list: command list if return_cmd=True.
+    """
+    avg, isotope, file_isotope = set_average(options)
 
     if options.kpoint is None:
         beg_k = 1
@@ -123,16 +121,38 @@ def print_lifetime_at_given_temperature():
             beg_s, end_s = int(arr[0]), int(arr[1])
         else:
             sys.exit("Invalid usage of --mode for --calc=tau")
+    if return_cmd:
+        command = [file_result, calc, avg,
+                   str(beg_k),  str(end_k),
+                   str(beg_s), str(end_s), options.temp,
+                   isotope, file_isotope]
+        return command
 
-    command = analyze_obj + file_result + " " + calc + " " + avg + " "\
-        + str(beg_k) + " " + str(end_k) + " "\
-        + str(beg_s) + " " + str(end_s) + " " + options.temp\
-        + " " + isotope + " " + file_isotope
+    else:
 
-    subprocess.call(command, shell=True)
+        command = analyze_obj + file_result + " " + calc + " " + avg + " "\
+            + str(beg_k) + " " + str(end_k) + " "\
+            + str(beg_s) + " " + str(end_s) + " " + options.temp\
+            + " " + isotope + " " + file_isotope
+
+        subprocess.call(command, shell=True)
 
 
-def print_thermal_conductivity():
+def print_thermal_conductivity(analyze_obj, calc, file_result, options, return_cmd=_RETURN_CMD_DEFAULT):
+    """def print_thermal_conductivity(analyze_obj, calc, file_result, options, return_cmd=_RETURN_CMD_DEFAULT):
+
+
+    Args:
+        analyze_obj (str): "analyze_phonon".
+        calc (_type_): calculation type.
+        file_result (_type_): result of RTA.
+        options (_type_): options of analyze_phonon.
+        return_cmd (_type_, optional): execute command or not. Defaults to _RETURN_CMD_DEFAULT.
+
+    Returns:
+        list: command list if return_cmd=True.
+    """
+    avg, isotope, file_isotope = set_average(options)
 
     if not (options.kpoint is None):
         print("# Warning: --kpoint option is discarded")
@@ -150,14 +170,34 @@ def print_thermal_conductivity():
         else:
             sys.exit("Invalid usage of --mode for --calc=kappa")
 
-    command = analyze_obj + file_result + " " + calc + " " + avg\
-        + " " + str(beg_s) + " " + str(end_s)\
-        + " " + isotope + " " + file_isotope
+    if return_cmd:
+        command = [file_result, calc, avg,
+                   str(beg_s), str(end_s),
+                   isotope, file_isotope]
+        return command
+    else:
+        command = analyze_obj + file_result + " " + calc + " " + avg\
+            + " " + str(beg_s) + " " + str(end_s)\
+            + " " + isotope + " " + file_isotope
 
-    subprocess.call(command, shell=True)
+        subprocess.call(command, shell=True)
 
 
-def print_thermal_conductivity_with_boundary():
+def print_thermal_conductivity_with_boundary(analyze_obj, calc, file_result, options, return_cmd=_RETURN_CMD_DEFAULT):
+    """def print_thermal_conductivity_with_boundary(analyze_obj, calc, file_result, options, return_cmd=_RETURN_CMD_DEFAULT):
+
+
+    Args:
+        analyze_obj (str): "analyze_phonon".
+        calc (str): calculation type.
+        file_result (str): result of RTA.
+        options (dict): options of analyze_phonon
+        return_cmd (_type_, optional): _description_. Defaults to _RETURN_CMD_DEFAULT.
+
+    Returns:
+        list: command list if return_cmd=True.
+    """
+    avg, isotope, file_isotope = set_average(options)
 
     if not (options.kpoint is None):
         print("# Warning: --kpoint option is discarded")
@@ -180,15 +220,37 @@ def print_thermal_conductivity_with_boundary():
     else:
         boundary_size = float(options.size)
 
-    command = analyze_obj + file_result + " " + calc + " " + avg\
-        + " " + str(beg_s) + " " + str(end_s)\
-        + " " + isotope + " " + file_isotope\
-        + " " + str(boundary_size)
+    if return_cmd:
+        command = [file_result, calc, avg,
+                   str(beg_s), str(end_s),
+                   isotope, file_isotope,
+                   str(boundary_size)]
+        return command
+    else:
+        command = analyze_obj + file_result + " " + calc + " " + avg\
+            + " " + str(beg_s) + " " + str(end_s)\
+            + " " + isotope + " " + file_isotope\
+            + " " + str(boundary_size)
 
-    subprocess.call(command, shell=True)
+        subprocess.call(command, shell=True)
 
 
-def print_cumulative_thermal_conductivity(cumulative_mode):
+def print_cumulative_thermal_conductivity(analyze_obj,  cumulative_mode,  file_result, options,  return_cmd=_RETURN_CMD_DEFAULT):
+    """print_cumulative_thermal_conductivity
+
+    Args:
+        analyze_obj (str): "analyze_phonon"
+        cumulative_mode (str): cumulative mode.
+        file_result (str): result of RTA.
+        options (dict): options of analyze_phonon.
+        return_cmd (bool, optional): execute command or not. Defaults to _RETURN_CMD_DEFAULT.
+
+    Returns:
+        list: list of command if return_cmd=True.
+    """
+
+    calc = cumulative_mode
+    avg, isotope, file_isotope = set_average(options)
 
     if options.temp is None:
         sys.exit("--temp is necessary when --calc=%s" % cumulative_mode)
@@ -219,11 +281,19 @@ def print_cumulative_thermal_conductivity(cumulative_mode):
         sys.exit("Invalid usage of --length option")
 
     if cumulative_mode == "cumulative":
-        command = analyze_obj + file_result + " " + calc + " " + avg + " "\
-            + str(beg_s) + " " + str(end_s)\
-            + " " + isotope + " " + file_isotope\
-            + " " + str(max_len) + " "\
-            + str(d_len) + " " + options.temp
+        if return_cmd:
+            command = [file_result, calc, avg,
+                       str(beg_s), str(end_s),
+                       isotope, file_isotope,
+                       str(max_len),
+                       str(d_len), options.temp]
+
+        else:
+            command = analyze_obj + file_result + " " + calc + " " + avg + " "\
+                + str(beg_s) + " " + str(end_s)\
+                + " " + isotope + " " + file_isotope\
+                + " " + str(max_len) + " "\
+                + str(d_len) + " " + options.temp
 
     else:
         size_flag = [0] * 3
@@ -239,55 +309,120 @@ def print_cumulative_thermal_conductivity(cumulative_mode):
             for i in range(len(options.direction.split(':'))):
                 size_flag[int(arr[i]) - 1] = 1
 
-        command = analyze_obj + file_result + " " + calc + " " + avg + " "\
-            + str(beg_s) + " " + str(end_s)\
-            + " " + isotope + " " + file_isotope\
-            + " " + str(max_len) + " " + str(d_len)\
-            + " " + options.temp + " " + str(size_flag[0]) \
-            + " " + str(size_flag[1]) + " " + str(size_flag[2])
+        if return_cmd:
+            command = [file_result, calc, avg,
+                       str(beg_s), str(end_s),
+                       isotope, file_isotope,
+                       str(max_len), str(d_len),
+                       options.temp, str(size_flag[0]),
+                       str(size_flag[1]), str(size_flag[2])]
+        else:
+            command = analyze_obj + file_result + " " + calc + " " + avg + " "\
+                + str(beg_s) + " " + str(end_s)\
+                + " " + isotope + " " + file_isotope\
+                + " " + str(max_len) + " " + str(d_len)\
+                + " " + options.temp + " " + str(size_flag[0]) \
+                + " " + str(size_flag[1]) + " " + str(size_flag[2])
 
-    subprocess.call(command, shell=True)
+    if return_cmd:
+        return command
+    else:
+        subprocess.call(command, shell=True)
 
 
 if __name__ == '__main__':
 
-    calc = options.calc
+    def main():
+        """make another main() to check whether global variables aren't used.
+        """
+        parser = optparse.OptionParser()
+        parser.add_option('--temp', help="target temperature to analyze")
+        parser.add_option('--mode', help="specify phonon mode index to print")
+        parser.add_option('--kpoint', help="specify k-point index to print")
 
-    if options.average_gamma:
-        avg = "1"
-    else:
-        avg = "0"
+        parser.add_option('--calc', metavar='tau|kappa|cumulative|cumulative2|kappa_boundary',
+                          help=('specify what to print. Available options are '
+                                'tau (Lifetime, mean-free-path, etc.), '
+                                'kappa (Thermal conductivity), '
+                                'cumulative (Cumulative thermal conductivity), '
+                                'cumulative2 (Cumulative thermal conductivity with specific xyz-directions), '
+                                'and kappa_boundary (Thermal conductivity with boundary effect). '
+                                'When --calc=cumulative2, please specify the '
+                                '--direction option. When --calc=kappa_boundary, '
+                                'please specify the --size option.'))
 
-    if options.isotope is None:
-        isotope = "0"
-        file_isotope = "none"
-    else:
-        isotope = "1"
-        file_isotope = options.isotope
+        parser.add_option('--isotope', metavar="PREFIX.self_isotope",
+                          help="specify the file PREFIX.self_isotope to include the \
+        effect of phonon-isotope scatterings. When given, the phonon scattering rates will be \
+        updated as 1/tau_{new} = 1/tau_{phonon-phonon} + 1/tau_{phonon-isotope}. \
+        The PREFIX.self_isotope can be generated using 'anphon' with ISOTOPE=2 option.")
 
-    # Compute phonon lifetimes, mean-free-path,
-    # and mode-decomposed thermal conductivity
-    if calc == "tau":
+        parser.add_option('--noavg', action="store_false", dest="average_gamma",
+                          default=True, help="do not average the damping function \
+        at degenerate points")
 
-        # When --temp option is not specified, print temperature dependence
-        # of phonon lifetimes at given mode and k point.
-        if options.temp is None:
-            print_temperature_dep_lifetime()
+        parser.add_option('--size', help="specify the grain boundary size in units of \
+        nm. The default value is 1000 nm.")
 
-        # When --temp option is specified, print phonon lifetimes and
-        # other quantities at the specified temperature.
+        parser.add_option('--length', metavar="Lmax:dL",
+                          help="specify the maximum value of system size L and its \
+        step dL in units of nm. \
+        The default value is --length=1000:10 .")
+
+        group = optparse.OptionGroup(parser,
+                                     "The following options are available/necessary \
+        when --calc=cumulative2 ")
+
+        group.add_option('--direction', metavar="1|2|3", help="specify which \
+        direction (xyz) to consider the size effect. \
+        When --direction=1 (2, 3), phonon mean-free-paths (ell) \
+        along x (y, z) are compared with the system size L. Then, \
+        the cumulative thermal conductivity is calculated by considering \
+        phonon modes satisfying ell <= L.")
+
+        parser.add_option_group(group)
+
+        options, args = parser.parse_args()
+        if len(args) == 0:
+            parser.print_help()
+            sys.exit(10)
+
+        file_result = args[0]
+
+        dir_obj = os.path.dirname(__file__)
+        analyze_obj = dir_obj + "/analyze_phonons "
+
+        calc = options.calc
+
+        # Compute phonon lifetimes, mean-free-path,
+        # and mode-decomposed thermal conductivity
+        if calc == "tau":
+
+            # When --temp option is not specified, print temperature dependence
+            # of phonon lifetimes at given mode and k point.
+            if options.temp is None:
+                print_temperature_dep_lifetime(
+                    analyze_obj, calc, file_result, options)
+
+            # When --temp option is specified, print phonon lifetimes and
+            # other quantities at the specified temperature.
+            else:
+                print_lifetime_at_given_temperature(
+                    analyze_obj, calc, file_result, options)
+
+        elif calc == "kappa":
+            print_thermal_conductivity(analyze_obj, calc, file_result, options)
+
+        # Compute cumulative thermal conductivity.
+        elif calc == "cumulative" or calc == "cumulative2":
+            print_cumulative_thermal_conductivity(
+                analyze_obj, calc, file_result, options)
+
+        elif calc == "kappa_boundary":
+            print_thermal_conductivity_with_boundary(
+                analyze_obj, calc, file_result, options)
+
         else:
-            print_lifetime_at_given_temperature()
+            sys.exit("Invalid --calc option given")
 
-    elif calc == "kappa":
-        print_thermal_conductivity()
-
-    # Compute cumulative thermal conductivity.
-    elif calc == "cumulative" or calc == "cumulative2":
-        print_cumulative_thermal_conductivity(calc)
-
-    elif calc == "kappa_boundary":
-        print_thermal_conductivity_with_boundary()
-
-    else:
-        sys.exit("Invalid --calc option given")
+    main()

--- a/tools/displace.py
+++ b/tools/displace.py
@@ -26,101 +26,6 @@ from interface.OpenMX import OpenmxParser
 from interface.LAMMPS import LammpsParser
 from GenDisplacement import AlamodeDisplace
 
-parser = argparse.ArgumentParser()
-
-parser.add_argument('--mag',
-                    type=float, default=0.02,
-                    help="Magnitude of displacement in units of \
-                        Angstrom (default: 0.02)")
-
-parser.add_argument('--prefix',
-                    type=str, default="disp",
-                    help="Prefix of the files to be created. (default: disp)")
-
-parser.add_argument('--QE',
-                    metavar='supercell.pw.in',
-                    help="Quantum-ESPRESSO input file with equilibrium atomic positions (default: None)")
-
-parser.add_argument('--VASP',
-                    metavar='SPOSCAR',
-                    help="VASP POSCAR file with equilibrium atomic \
-                        positions (default: None)")
-
-parser.add_argument('--xTAPP',
-                    metavar='supercell.cg',
-                    help="xTAPP CG file with equilibrium atomic \
-                        positions (default: None)")
-
-parser.add_argument('--LAMMPS',
-                    metavar='supercell.lammps',
-                    help="LAMMPS structure file with equilibrium atomic positions (default: None)")
-
-parser.add_argument('--OpenMX',
-                    metavar='supercell.dat',
-                    help="dat file with equilibrium atomic \
-                        positions (default: None)")
-
-parser.add_argument('-pf', '--pattern_file', metavar='prefix.pattern_*', type=str, nargs='+',
-                    help="ALM pattern file(s) generated with MODE = suggest")
-
-parser.add_argument('--random', action="store_true", dest="random", default=False,
-                    help="Generate randomly-displaced structures.")
-
-parser.add_argument('--random_normalcoord', action="store_true", dest="random_normalcoord", default=False,
-                    help="Generate randomly-displaced structures in normal coordinate basis. "
-                         "Please give the --temp option as well.")
-
-parser.add_argument('--temp', type=float, default=100,
-                    help="Target temperature of the random distribution of \
-                        Q (default: 100). Used if --MD is not given.")
-
-parser.add_argument('--ignore_imag', action="store_true", dest="ignore_imag", default=False,
-                    help="Ignore imaginary modes when generating random displacements by"
-                         "--random_normalcoord option. By default, imaginary frequency"
-                         "will be replaced with its absolute value.")
-
-parser.add_argument('-e', '--every', type=str, default="50", metavar='start:end:interval',
-                    help="Specify the range and interval of data sampling. "
-                         "--every=1:1000:10 means sampling one structure for every 10 snapshots"
-                         "from the 1st step to the 1000th step. Used if --MD is given."
-                         "(default: 50)")
-
-parser.add_argument('-md', '--load_mddata', type=str, nargs='+', default=None,
-                    help="Specify the file(s) containing displacements of MD trajectories.")
-
-parser.add_argument('--prim', type=str, default=None,
-                    help="Specify the file containing structure data of the primitive lattice.")
-
-parser.add_argument('--evec', type=str, default=None,
-                    help="Specify the filename containing eigenvalues and eigenvectors.")
-
-parser.add_argument('-nd', '--num_disp', type=int, default=1,
-                    help="Specify the number of displacement patterns.")
-
-parser.add_argument('-cl', '--classical', action="store_true", dest="classical", default=False,
-                    help="Use classical expectation value for <Q^2>.")
-
-parser.add_argument('-p', '--print', action="store_true", dest="print_disp_stdout", default=False,
-                    help="Print displacements to stdout. The unit is Angstrom.")
-
-parser.add_argument('--pes', type=str, default=None, metavar='"q_index branch_index"',
-                    help="Specify the target mode to displace atoms for calculating "
-                         "the potential energy surface. --pes='5 10' will generate displacements"
-                         "that correspond to the phonon mode at the 5th q point and the 10th branch."
-                         "Only the real part of the phonon eigenvector is used by default."
-                         "To use the imaginary part instead, please add --imag-evec option.")
-
-parser.add_argument('--imag_evec', action="store_true", dest="imag_evec", default=False,
-                    help="In the --pes mode, the imaginary part of the phonon eigenvectors"
-                         "will be used when --imag_evec option is given. By default, the"
-                         "real part of the eigenvectors are used. Please be noted that "
-                         "adding this option generates zero displacements for the phonon modes"
-                         "at the Brillouin zone center and boundaries because the eigenvectors"
-                         "at these points are purely real.")
-
-parser.add_argument('--Qrange', type=str, default=None, metavar='"Qmin Qmax"',
-                    help='Range of normal coordinate amplitude Q in units of amu^{1/2}*Angstrom')
-
 
 def check_code_options(args):
     conditions = [args.VASP is None,
@@ -216,7 +121,8 @@ def check_displace_options(args, code):
               "extract.py with --get disp option.\n" % code)
 
     if (args.pes or displacement_mode == "random_normalcoordinate") and code == "LAMMPS":
-        raise RuntimeError("sorry. --random_normalcoord and --pes are not supported for LAMMPS.")
+        raise RuntimeError(
+            "sorry. --random_normalcoord and --pes are not supported for LAMMPS.")
 
     return displacement_mode
 
@@ -276,6 +182,101 @@ def print_displacement_stdout(disp_list, codeobj):
 
 
 if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--mag',
+                        type=float, default=0.02,
+                        help="Magnitude of displacement in units of \
+                            Angstrom (default: 0.02)")
+
+    parser.add_argument('--prefix',
+                        type=str, default="disp",
+                        help="Prefix of the files to be created. (default: disp)")
+
+    parser.add_argument('--QE',
+                        metavar='supercell.pw.in',
+                        help="Quantum-ESPRESSO input file with equilibrium atomic positions (default: None)")
+
+    parser.add_argument('--VASP',
+                        metavar='SPOSCAR',
+                        help="VASP POSCAR file with equilibrium atomic \
+                            positions (default: None)")
+
+    parser.add_argument('--xTAPP',
+                        metavar='supercell.cg',
+                        help="xTAPP CG file with equilibrium atomic \
+                            positions (default: None)")
+
+    parser.add_argument('--LAMMPS',
+                        metavar='supercell.lammps',
+                        help="LAMMPS structure file with equilibrium atomic positions (default: None)")
+
+    parser.add_argument('--OpenMX',
+                        metavar='supercell.dat',
+                        help="dat file with equilibrium atomic \
+                            positions (default: None)")
+
+    parser.add_argument('-pf', '--pattern_file', metavar='prefix.pattern_*', type=str, nargs='+',
+                        help="ALM pattern file(s) generated with MODE = suggest")
+
+    parser.add_argument('--random', action="store_true", dest="random", default=False,
+                        help="Generate randomly-displaced structures.")
+
+    parser.add_argument('--random_normalcoord', action="store_true", dest="random_normalcoord", default=False,
+                        help="Generate randomly-displaced structures in normal coordinate basis. "
+                        "Please give the --temp option as well.")
+
+    parser.add_argument('--temp', type=float, default=100,
+                        help="Target temperature of the random distribution of \
+                            Q (default: 100). Used if --MD is not given.")
+
+    parser.add_argument('--ignore_imag', action="store_true", dest="ignore_imag", default=False,
+                        help="Ignore imaginary modes when generating random displacements by"
+                        "--random_normalcoord option. By default, imaginary frequency"
+                        "will be replaced with its absolute value.")
+
+    parser.add_argument('-e', '--every', type=str, default="50", metavar='start:end:interval',
+                        help="Specify the range and interval of data sampling. "
+                        "--every=1:1000:10 means sampling one structure for every 10 snapshots"
+                        "from the 1st step to the 1000th step. Used if --MD is given."
+                        "(default: 50)")
+
+    parser.add_argument('-md', '--load_mddata', type=str, nargs='+', default=None,
+                        help="Specify the file(s) containing displacements of MD trajectories.")
+
+    parser.add_argument('--prim', type=str, default=None,
+                        help="Specify the file containing structure data of the primitive lattice.")
+
+    parser.add_argument('--evec', type=str, default=None,
+                        help="Specify the filename containing eigenvalues and eigenvectors.")
+
+    parser.add_argument('-nd', '--num_disp', type=int, default=1,
+                        help="Specify the number of displacement patterns.")
+
+    parser.add_argument('-cl', '--classical', action="store_true", dest="classical", default=False,
+                        help="Use classical expectation value for <Q^2>.")
+
+    parser.add_argument('-p', '--print', action="store_true", dest="print_disp_stdout", default=False,
+                        help="Print displacements to stdout. The unit is Angstrom.")
+
+    parser.add_argument('--pes', type=str, default=None, metavar='"q_index branch_index"',
+                        help="Specify the target mode to displace atoms for calculating "
+                        "the potential energy surface. --pes='5 10' will generate displacements"
+                        "that correspond to the phonon mode at the 5th q point and the 10th branch."
+                        "Only the real part of the phonon eigenvector is used by default."
+                        "To use the imaginary part instead, please add --imag-evec option.")
+
+    parser.add_argument('--imag_evec', action="store_true", dest="imag_evec", default=False,
+                        help="In the --pes mode, the imaginary part of the phonon eigenvectors"
+                        "will be used when --imag_evec option is given. By default, the"
+                        "real part of the eigenvectors are used. Please be noted that "
+                        "adding this option generates zero displacements for the phonon modes"
+                        "at the Brillouin zone center and boundaries because the eigenvectors"
+                        "at these points are purely real.")
+
+    parser.add_argument('--Qrange', type=str, default=None, metavar='"Qmin Qmax"',
+                        help='Range of normal coordinate amplitude Q in units of amu^{1/2}*Angstrom')
 
     args = parser.parse_args()
 

--- a/tools/extract.py
+++ b/tools/extract.py
@@ -20,73 +20,20 @@ and energies.
 
 from __future__ import print_function
 import argparse
-from interface.VASP import VaspParser
-from interface.QE import QEParser
-from interface.xTAPP import XtappParser
-from interface.OpenMX import OpenmxParser
-from interface.LAMMPS import LammpsParser
+try:
+    from interface.VASP import VaspParser
+    from interface.QE import QEParser
+    from interface.xTAPP import XtappParser
+    from interface.OpenMX import OpenmxParser
+    from interface.LAMMPS import LammpsParser
 
-parser = argparse.ArgumentParser()
+except ModuleNotFoundError: # occurs when it is called as a library
+    from .interface.VASP import VaspParser    
+    from .interface.QE import QEParser
+    from .interface.xTAPP import XtappParser
+    from .interface.OpenMX import OpenmxParser
+    from .interface.LAMMPS import LammpsParser
 
-parser.add_argument('--VASP',
-                    metavar='SPOSCAR',
-                    help="VASP POSCAR file with equilibrium atomic \
-                        positions (default: None)")
-
-parser.add_argument('--QE',
-                    metavar='supercell.pw.in',
-                    help="Quantum-ESPRESSO input file with equilibrium\
-                  atomic positions (default: None)")
-
-parser.add_argument('--xTAPP',
-                    metavar='supercell.cg',
-                    help="xTAPP CG file with equilibrium atomic \
-                        positions (default: None)")
-
-parser.add_argument('--LAMMPS',
-                    metavar='supercell.lammps',
-                    help="LAMMPS structure file with equilibrium atomic \
-                        positions (default: None)")
-
-parser.add_argument('--OpenMX',
-                    metavar='supercell.dat',
-                    help="OpenMX dat file with equilibrium atomic \
-                        positions (default: None)")
-
-parser.add_argument('--get',
-                    default="disp-force",
-                    help="specify which quantity to extract. \
-                        Available options are 'disp-force', 'disp', \
-                        'force', 'energy', and 'born'. \
-                        (default: disp-force)")
-
-parser.add_argument('--unit',
-                    action="store",
-                    metavar="OUTPUT_UNIT",
-                    dest="unitname",
-                    default="Rydberg",
-                    help="print atomic displacements and forces in units of UNIT. \
-                          Available options are 'eV', 'Rydberg' (default), and 'Hartree'.")
-
-parser.add_argument('--offset',
-                    help="Specify an output file (either *.xml, *.pw.out, or *.str) of an\
-                         equilibrium structure to subtract residual forces, \
-                         displacements, or energies.")
-
-parser.add_argument('--emin',
-                    default=None,
-                    type=float,
-                    help="Lower bound of the energy filter (eV) used for selecting output structures.\
-                        Available only in the VASP parser.")
-
-parser.add_argument('--emax',
-                    default=None,
-                    type=float,
-                    help="Upper bound of the energy filter (eV) used for selecting output structures.\
-                        Available only in the VASP parser.")
-
-parser.add_argument('target_file', metavar='file_to_parse', type=str, nargs='+',
-                    help="Output file of DFT codes, e.g., vasprun.xml.")
 
 
 def check_options(args):
@@ -131,7 +78,8 @@ def check_options(args):
     # Check output option
     str_get = args.get.lower()
     if str_get not in ["disp-force", "disp", "force", "energy", "born", "dielec"]:
-        raise RuntimeError("Error: Please specify which quantity to extract by the --get option.")
+        raise RuntimeError(
+            "Error: Please specify which quantity to extract by the --get option.")
 
     print_disp = False
     print_force = False
@@ -150,7 +98,8 @@ def check_options(args):
     elif str_get == "born" or str_get == "dielec":
         print_borninfo = True
         if code != "VASP" and code != "QE":
-            raise RuntimeError("Sorry, --get born is available only for VASP and QE.")
+            raise RuntimeError(
+                "Sorry, --get born is available only for VASP and QE.")
 
     output_flags = [print_disp, print_force, print_energy, print_borninfo]
 
@@ -189,10 +138,73 @@ def run_parse(args, code, file_original, file_results, output_flags, str_unit):
     handler.parse(file_original, file_results, args.offset,
                   str_unit, output_flags, args.emin, args.emax)
 
+
 if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--VASP',
+                        metavar='SPOSCAR',
+                        help="VASP POSCAR file with equilibrium atomic \
+                            positions (default: None)")
+
+    parser.add_argument('--QE',
+                        metavar='supercell.pw.in',
+                        help="Quantum-ESPRESSO input file with equilibrium\
+                    atomic positions (default: None)")
+
+    parser.add_argument('--xTAPP',
+                        metavar='supercell.cg',
+                        help="xTAPP CG file with equilibrium atomic \
+                            positions (default: None)")
+
+    parser.add_argument('--LAMMPS',
+                        metavar='supercell.lammps',
+                        help="LAMMPS structure file with equilibrium atomic \
+                            positions (default: None)")
+
+    parser.add_argument('--OpenMX',
+                        metavar='supercell.dat',
+                        help="OpenMX dat file with equilibrium atomic \
+                            positions (default: None)")
+
+    parser.add_argument('--get',
+                        default="disp-force",
+                        help="specify which quantity to extract. \
+                            Available options are 'disp-force', 'disp', \
+                            'force', 'energy', and 'born'. \
+                            (default: disp-force)")
+
+    parser.add_argument('--unit',
+                        action="store",
+                        metavar="OUTPUT_UNIT",
+                        dest="unitname",
+                        default="Rydberg",
+                        help="print atomic displacements and forces in units of UNIT. \
+                            Available options are 'eV', 'Rydberg' (default), and 'Hartree'.")
+
+    parser.add_argument('--offset',
+                        help="Specify an output file (either *.xml, *.pw.out, or *.str) of an\
+                            equilibrium structure to subtract residual forces, \
+                            displacements, or energies.")
+
+    parser.add_argument('--emin',
+                        default=None,
+                        type=float,
+                        help="Lower bound of the energy filter (eV) used for selecting output structures.\
+                            Available only in the VASP parser.")
+
+    parser.add_argument('--emax',
+                        default=None,
+                        type=float,
+                        help="Upper bound of the energy filter (eV) used for selecting output structures.\
+                            Available only in the VASP parser.")
+
+    parser.add_argument('target_file', metavar='file_to_parse', type=str, nargs='+',
+                        help="Output file of DFT codes, e.g., vasprun.xml.")
 
     args = parser.parse_args()
     file_results = args.target_file
-    
+
     code, file_original, output_flags, str_unit = check_options(args)
     run_parse(args, code, file_original, file_results, output_flags, str_unit)

--- a/tools/plotdos.py
+++ b/tools/plotdos.py
@@ -17,19 +17,6 @@ import matplotlib.pyplot as plt
 import matplotlib as mpl
 
 # parser options
-usage = "usage: %prog [options] file1.dos file2.dos ... "
-parser = optparse.OptionParser(usage=usage)
-
-parser.add_option("--pdos", action="store_true", dest="print_pdos", default=False,
-                  help="print atom-projected phonon DOS")
-parser.add_option("--nokey", action="store_false", dest="print_key", default=True,
-                  help="don't print the key in the figure")
-parser.add_option("-u", "--unit", action="store", type="string", dest="unitname", default="kayser",
-                  help="print the band dispersion in units of UNIT. Available options are kayser, meV, and THz", metavar="UNIT")
-parser.add_option("--emin", action="store", type="float", dest="emin",
-                  help="minimum value of the energy axis")
-parser.add_option("--emax", action="store", type="float", dest="emax",
-                  help="maximum value of the energy axis")
 
 
 # font styles
@@ -133,19 +120,7 @@ def sum_atom_projected_dos(pdos_tmp, natoms_tmp):
     return pdos_sum
 
 
-if __name__ == '__main__':
-
-    options, args = parser.parse_args()
-    files = args[0:]
-    nfiles = len(files)
-
-    if nfiles == 0:
-        print("Usage: plotdos.py [options] file1.dos file2.dos ...")
-        print("For details of available options, please type\n$ python plotdos.py -h")
-        exit(1)
-    else:
-        print("Number of files = %d" % nfiles)
-
+def run_plot(files,  unitname='kayser', print_pdos=False, print_key=False, emin=None, emax=None, show=True):
     energy_axis = []
     dos_merged = []
 
@@ -154,7 +129,7 @@ if __name__ == '__main__':
         energy_axis.append(data_tmp[:, 0])
         dos_merged.append(data_tmp[:, 1:])
 
-    energy_axis = change_xscale(energy_axis, options.unitname)
+    energy_axis = change_xscale(energy_axis, unitname)
     xmin, xmax = get_x_minmax(energy_axis)
     ymin, ymax = get_y_minmax(dos_merged)
 
@@ -168,7 +143,7 @@ if __name__ == '__main__':
 
         counter_line += 1
 
-        if options.print_pdos:
+        if print_pdos:
             symbols, natoms = get_natoms_and_symbols(files[i])
 
             if len(dos_merged[i][0, 1:]) != np.sum(natoms):
@@ -185,24 +160,24 @@ if __name__ == '__main__':
 
                     counter_line += 1
 
-    if options.unitname.lower() == "mev":
+    if unitname.lower() == "mev":
         plt.xlabel("Frequency (meV)", fontsize=16)
-    elif options.unitname.lower() == "thz":
+    elif unitname.lower() == "thz":
         plt.xlabel("Frequency (THz)", fontsize=16)
     else:
         plt.xlabel("Frequency (cm${}^{-1}$)", fontsize=16)
 
     plt.ylabel("Phonon DOS", fontsize=16, labelpad=20)
 
-    if options.emin == None and options.emax == None:
+    if emin == None and emax == None:
         factor = 1.00
         xmin *= factor
         xmax *= factor
     else:
-        if options.emin != None:
-            xmin = options.emin
-        if options.emax != None:
-            xmax = options.emax
+        if emin != None:
+            xmin = emin
+        if emax != None:
+            xmax = emax
 
         if xmin > xmax:
             print("Warning: emin > emax")
@@ -213,8 +188,40 @@ if __name__ == '__main__':
     plt.xticks(fontsize=16)
     plt.yticks([])
 
-    if options.print_key:
+    if print_key:
         plt.legend(loc='upper right', prop={'size': 12})
 
     plt.tight_layout()
-    plt.show()
+    if show:
+        plt.show()
+
+
+if __name__ == '__main__':
+
+    usage = "usage: %prog [options] file1.dos file2.dos ... "
+    parser = optparse.OptionParser(usage=usage)
+
+    parser.add_option("--pdos", action="store_true", dest="print_pdos", default=False,
+                      help="print atom-projected phonon DOS")
+    parser.add_option("--nokey", action="store_false", dest="print_key", default=True,
+                      help="don't print the key in the figure")
+    parser.add_option("-u", "--unit", action="store", type="string", dest="unitname", default="kayser",
+                      help="print the band dispersion in units of UNIT. Available options are kayser, meV, and THz", metavar="UNIT")
+    parser.add_option("--emin", action="store", type="float", dest="emin",
+                      help="minimum value of the energy axis")
+    parser.add_option("--emax", action="store", type="float", dest="emax",
+                      help="maximum value of the energy axis")
+
+    options, args = parser.parse_args()
+    files = args[0:]
+    nfiles = len(files)
+
+    if nfiles == 0:
+        print("Usage: plotdos.py [options] file1.dos file2.dos ...")
+        print("For details of available options, please type\n$ python plotdos.py -h")
+        exit(1)
+    else:
+        print("Number of files = %d" % nfiles)
+
+    run_plot(files,  options.unitname, 
+             options.print_pdos, options.print_key, options.emin, options.emax)


### PR DESCRIPTION
There exists functions where global variables are used among functions in the stand alone programs, such as displace.py, extract.py and so on in tools/*.py.  Their arguments are explictly added and I beilieve that they are tested.
Alamode_aiida uses them as libraries where the global variables can't be referred among functions. These changes are necessary for alamode_aiida.