### PR TITLE
Optimized PERIODIC_IMAGE_CONV=1

### DIFF
--- a/alm/alm.cpp
+++ b/alm/alm.cpp
@@ -397,7 +397,7 @@ size_t ALM::get_number_of_irred_fc_elements(const int fc_order) // harmonic=1, .
                           cluster,
                           symmetry,
                           get_optimizer_control().linear_model,
-                          get_optimizer_control().mirror_image_conv,
+                          get_optimizer_control().periodic_image_conv,
                           verbosity,
                           timer);
         initialized_constraint_class = true;
@@ -408,7 +408,7 @@ size_t ALM::get_number_of_irred_fc_elements(const int fc_order) // harmonic=1, .
                                              cluster,
                                              fcs,
                                              verbosity,
-                                             get_optimizer_control().mirror_image_conv);
+                                             get_optimizer_control().periodic_image_conv);
     }
 
     return constraint->get_index_bimap(order).size();
@@ -506,7 +506,7 @@ void ALM::get_fc_irreducible(double *fc_values,
                           cluster,
                           symmetry,
                           get_optimizer_control().linear_model,
-                          get_optimizer_control().mirror_image_conv,
+                          get_optimizer_control().periodic_image_conv,
                           verbosity,
                           timer);
         initialized_constraint_class = true;
@@ -517,7 +517,7 @@ void ALM::get_fc_irreducible(double *fc_values,
                                              cluster,
                                              fcs,
                                              verbosity,
-                                             get_optimizer_control().mirror_image_conv);
+                                             get_optimizer_control().periodic_image_conv);
     }
 
     size_t ishift = 0;
@@ -634,7 +634,7 @@ void ALM::get_matrix_elements(double *amat,
                           cluster,
                           symmetry,
                           get_optimizer_control().linear_model,
-                          get_optimizer_control().mirror_image_conv,
+                          get_optimizer_control().periodic_image_conv,
                           verbosity,
                           timer);
         initialized_constraint_class = true;
@@ -645,7 +645,7 @@ void ALM::get_matrix_elements(double *amat,
                                              cluster,
                                              fcs,
                                              verbosity,
-                                             get_optimizer_control().mirror_image_conv);
+                                             get_optimizer_control().periodic_image_conv);
     }
 
     optimize->get_matrix_elements_algebraic_constraint(maxorder,
@@ -683,7 +683,7 @@ int ALM::run_optimize()
                           cluster,
                           symmetry,
                           get_optimizer_control().linear_model,
-                          get_optimizer_control().mirror_image_conv,
+                          get_optimizer_control().periodic_image_conv,
                           verbosity,
                           timer);
         initialized_constraint_class = true;
@@ -694,7 +694,7 @@ int ALM::run_optimize()
                                              cluster,
                                              fcs,
                                              verbosity,
-                                             get_optimizer_control().mirror_image_conv);
+                                             get_optimizer_control().periodic_image_conv);
     }
 
     const auto maxorder = cluster->get_maxorder();
@@ -740,7 +740,7 @@ void ALM::init_fc_table()
     // Build cluster & force constant table
     cluster->init(system,
                   symmetry,
-                  get_optimizer_control().mirror_image_conv,
+                  get_optimizer_control().periodic_image_conv,
                   verbosity,
                   timer);
     fcs->init(cluster,

--- a/alm/cluster.cpp
+++ b/alm/cluster.cpp
@@ -38,7 +38,7 @@ Cluster::~Cluster()
 
 void Cluster::init(const System *system,
                    const Symmetry *symmetry,
-                   const int mirror_image_conv,
+                   const int periodic_image_conv,
                    const int verbosity,
                    Timer *timer)
 {
@@ -111,14 +111,14 @@ void Cluster::init(const System *system,
                               symmetry->get_map_p2s(),
                               system->get_x_image(),
                               system->get_exist_image(),
-                              mirror_image_conv);
+                              periodic_image_conv);
 
     generate_pairs(symmetry->get_nat_prim(),
                    symmetry->get_map_p2s(),
                    cluster_list);
 
     // check permutation symmetry of anharmonic IFC
-    if (mirror_image_conv > 0) {
+    if (periodic_image_conv > 0) {
         std::cout << "check permutation symmetry of the clusters." << std::endl;
         std::cout << "(if no message is printed out, the permutation symmetry is satisfied.)" << std::endl;
         for (auto order = 1; order < maxorder; ++order) {
@@ -232,7 +232,7 @@ void Cluster::check_permutation_symmetry(const System *system,
     int iat_translated, jat_translated, j2at_translated;
     int iat_prim;
     int jat_prim;
-    int i_mirror;
+    int i_periodic;
     std::vector<int> data_now;
     std::vector<std::vector<int>> cell_dummy;
 
@@ -305,16 +305,16 @@ void Cluster::check_permutation_symmetry(const System *system,
 
                 // prepare relative vector for comparison
                 relvecs1.clear();
-                for (i_mirror = 0; i_mirror < cluster_tmp.cell.size(); i_mirror++) {
+                for (i_periodic = 0; i_periodic < cluster_tmp.cell.size(); i_periodic++) {
                     relvecs1.emplace_back(RelativeVectors(order));
                     // first relative vector
                     relvec_tmp.clear();
                     for (xyztmp = 0; xyztmp < 3; xyztmp++) {
                         dtmp1 = system->get_x_image()[0][iat][xyztmp] -
-                                system->get_x_image()[cluster_tmp.cell[i_mirror][j]][jat][xyztmp];
+                                system->get_x_image()[cluster_tmp.cell[i_periodic][j]][jat][xyztmp];
                         relvec_tmp.push_back(dtmp1);
                     }
-                    relvecs1[i_mirror].relvecs_cartesian.push_back(relvec_tmp);
+                    relvecs1[i_periodic].relvecs_cartesian.push_back(relvec_tmp);
 
                     // other relative vectors
                     for (j2 = 0; j2 < order + 1; j2++) {
@@ -324,39 +324,39 @@ void Cluster::check_permutation_symmetry(const System *system,
                         relvec_tmp.clear();
                         for (xyztmp = 0; xyztmp < 3; xyztmp++) {
                             j2at = cluster_tmp.atom[j2];
-                            dtmp1 = system->get_x_image()[cluster_tmp.cell[i_mirror][j2]][j2at][xyztmp] -
-                                    system->get_x_image()[cluster_tmp.cell[i_mirror][j]][jat][xyztmp];
+                            dtmp1 = system->get_x_image()[cluster_tmp.cell[i_periodic][j2]][j2at][xyztmp] -
+                                    system->get_x_image()[cluster_tmp.cell[i_periodic][j]][jat][xyztmp];
                             relvec_tmp.push_back(dtmp1);
                         }
-                        relvecs1[i_mirror].relvecs_cartesian.push_back(relvec_tmp);
+                        relvecs1[i_periodic].relvecs_cartesian.push_back(relvec_tmp);
                     }
 
-                    relvecs1[i_mirror].make_fractional_from_cartesian(
+                    relvecs1[i_periodic].make_fractional_from_cartesian(
                             system->get_supercell().reciprocal_lattice_vector);
                 }
 
                 relvecs2.clear();
-                for (i_mirror = 0; i_mirror < (*cluster_tmp2).cell.size(); i_mirror++) {
+                for (i_periodic = 0; i_periodic < (*cluster_tmp2).cell.size(); i_periodic++) {
                     relvecs2.emplace_back(RelativeVectors(order));
 
                     for (j2 = 0; j2 < order + 1; j2++) {
                         relvec_tmp.clear();
                         for (xyztmp = 0; xyztmp < 3; xyztmp++) {
                             j2at = (*cluster_tmp2).atom[j2];
-                            dtmp1 = system->get_x_image()[(*cluster_tmp2).cell[i_mirror][j2]][j2at][xyztmp] -
+                            dtmp1 = system->get_x_image()[(*cluster_tmp2).cell[i_periodic][j2]][j2at][xyztmp] -
                                     system->get_x_image()[0][symmetry->get_map_p2s()[jat_prim][0]][xyztmp];
                             relvec_tmp.push_back(dtmp1);
                         }
-                        relvecs2[i_mirror].relvecs_cartesian.push_back(relvec_tmp);
+                        relvecs2[i_periodic].relvecs_cartesian.push_back(relvec_tmp);
                     }
 
-                    relvecs2[i_mirror].make_fractional_from_cartesian(
+                    relvecs2[i_periodic].make_fractional_from_cartesian(
                             system->get_supercell().reciprocal_lattice_vector);
                 }
 
                 if (relvecs1.size() != relvecs2.size()) {
                     std::cout << "permutation symmetry is NOT satisfied: ";
-                    std::cout << "multiplicity of mirror image is different" << std::endl;
+                    std::cout << "multiplicity of periodic image is different" << std::endl;
 
 
                     std::cout << "information on current cluster: " << std::endl;
@@ -375,30 +375,30 @@ void Cluster::check_permutation_symmetry(const System *system,
 
                     // print relative vectors
                     std::cout << "relative vectors in current cluster (fractional, cartesian): " << std::endl;
-                    for (i_mirror = 0; i_mirror < cluster_tmp.cell.size(); i_mirror++) {
-                        std::cout << "mirror image pattern: " << i_mirror << std::endl;
+                    for (i_periodic = 0; i_periodic < cluster_tmp.cell.size(); i_periodic++) {
+                        std::cout << "periodic image pattern: " << i_periodic << std::endl;
                         for (itmp = 0; itmp < order + 1; itmp++) {
                             for (xyztmp = 0; xyztmp < 3; xyztmp++) {
-                                std::cout << relvecs1[i_mirror].relvecs_fractional[itmp][xyztmp] << " ";
+                                std::cout << relvecs1[i_periodic].relvecs_fractional[itmp][xyztmp] << " ";
                             }
                             std::cout << ", ";
                             for (xyztmp = 0; xyztmp < 3; xyztmp++) {
-                                std::cout << relvecs1[i_mirror].relvecs_cartesian[itmp][xyztmp] << " ";
+                                std::cout << relvecs1[i_periodic].relvecs_cartesian[itmp][xyztmp] << " ";
                             }
                             std::cout << std::endl;
                         }
                     }
 
                     std::cout << "relative vectors in corresponding cluster (fractional, cartesian): " << std::endl;
-                    for (i_mirror = 0; i_mirror < (*cluster_tmp2).cell.size(); i_mirror++) {
-                        std::cout << "mirror image pattern: " << i_mirror << std::endl;
+                    for (i_periodic = 0; i_periodic < (*cluster_tmp2).cell.size(); i_periodic++) {
+                        std::cout << "periodic image pattern: " << i_periodic << std::endl;
                         for (itmp = 0; itmp < order + 1; itmp++) {
                             for (xyztmp = 0; xyztmp < 3; xyztmp++) {
-                                std::cout << relvecs2[i_mirror].relvecs_fractional[itmp][xyztmp] << " ";
+                                std::cout << relvecs2[i_periodic].relvecs_fractional[itmp][xyztmp] << " ";
                             }
                             std::cout << ", ";
                             for (xyztmp = 0; xyztmp < 3; xyztmp++) {
-                                std::cout << relvecs2[i_mirror].relvecs_cartesian[itmp][xyztmp] << " ";
+                                std::cout << relvecs2[i_periodic].relvecs_cartesian[itmp][xyztmp] << " ";
                             }
                             std::cout << std::endl;
                         }
@@ -426,7 +426,7 @@ void Cluster::check_permutation_symmetry(const System *system,
                     }
                     if (is_found == 0) {
                         std::cout << "permutation symmetry is not satisfied: ";
-                        std::cout << "mirror image is different." << std::endl;
+                        std::cout << "periodic image is different." << std::endl;
 
                         std::cout << "information on current cluster: " << std::endl;
                         std::cout << "center atom(in primitive cell) = " << iat_prim;
@@ -444,38 +444,38 @@ void Cluster::check_permutation_symmetry(const System *system,
 
                         // print relative vectors
                         std::cout << "relative vectors in current cluster (fractional, cartesian): " << std::endl;
-                        for (i_mirror = 0; i_mirror < cluster_tmp.cell.size(); i_mirror++) {
-                            std::cout << "mirror image pattern: " << i_mirror << std::endl;
+                        for (i_periodic = 0; i_periodic < cluster_tmp.cell.size(); i_periodic++) {
+                            std::cout << "periodic image pattern: " << i_periodic << std::endl;
                             for (itmp = 0; itmp < order + 1; itmp++) {
                                 for (xyztmp = 0; xyztmp < 3; xyztmp++) {
-                                    std::cout << relvecs1[i_mirror].relvecs_fractional[itmp][xyztmp] << " ";
+                                    std::cout << relvecs1[i_periodic].relvecs_fractional[itmp][xyztmp] << " ";
                                 }
                                 std::cout << ", ";
                                 for (xyztmp = 0; xyztmp < 3; xyztmp++) {
-                                    std::cout << relvecs1[i_mirror].relvecs_cartesian[itmp][xyztmp] << " ";
+                                    std::cout << relvecs1[i_periodic].relvecs_cartesian[itmp][xyztmp] << " ";
                                 }
                                 std::cout << std::endl;
                             }
                         }
 
                         std::cout << "relative vectors in corresponding cluster (fractional, cartesian): " << std::endl;
-                        for (i_mirror = 0; i_mirror < (*cluster_tmp2).cell.size(); i_mirror++) {
-                            std::cout << "mirror image pattern: " << i_mirror << std::endl;
+                        for (i_periodic = 0; i_periodic < (*cluster_tmp2).cell.size(); i_periodic++) {
+                            std::cout << "periodic image pattern: " << i_periodic << std::endl;
                             for (itmp = 0; itmp < order + 1; itmp++) {
                                 for (xyztmp = 0; xyztmp < 3; xyztmp++) {
-                                    std::cout << relvecs2[i_mirror].relvecs_fractional[itmp][xyztmp] << " ";
+                                    std::cout << relvecs2[i_periodic].relvecs_fractional[itmp][xyztmp] << " ";
                                 }
                                 std::cout << ", ";
                                 for (xyztmp = 0; xyztmp < 3; xyztmp++) {
-                                    std::cout << relvecs2[i_mirror].relvecs_cartesian[itmp][xyztmp] << " ";
+                                    std::cout << relvecs2[i_periodic].relvecs_cartesian[itmp][xyztmp] << " ";
                                 }
                                 std::cout << std::endl;
                             }
                         }
-                        std::cout << "corresponding mirror image does not exist for " << itmp
-                                  << "-th mirror image in current cluster" << std::endl;
+                        std::cout << "corresponding periodic image does not exist for " << itmp
+                                  << "-th periodic image in current cluster" << std::endl;
                     } else {
-                        // std::cout << "corresponding mirror image is found for " << itmp << "-th mirror image in current cluster" << std::endl;
+                        // std::cout << "corresponding periodic image is found for " << itmp << "-th periodic image in current cluster" << std::endl;
                     }
                 }
 
@@ -613,7 +613,7 @@ void Cluster::get_pairs_of_minimum_distance(const size_t nat,
             const auto dist_min = distall[i][j][0].dist;
             for (auto it = distall[i][j].cbegin(); it != distall[i][j].cend(); ++it) {
                 // The tolerance below (1.e-3) should be chosen so that
-                // the mirror images with equal distances are found correctly.
+                // the periodic images with equal distances are found correctly.
                 // If this fails, the phonon dispersion would be incorrect.
                 if (std::abs((*it).dist - dist_min) < 1.0e-3) {
                     mindist_pairs[i][j].emplace_back(DistInfo(*it));
@@ -974,7 +974,7 @@ void Cluster::calc_interaction_clusters(const size_t natmin,
                                         const std::vector<std::vector<int>> &map_p2s,
                                         const double *const *const *x_image,
                                         const int *exist,
-                                        const int mirror_image_conv) const
+                                        const int periodic_image_conv) const
 {
     //
     // Calculate the complete set of clusters for all orders.
@@ -988,7 +988,7 @@ void Cluster::calc_interaction_clusters(const size_t natmin,
                                 interaction_pair[order],
                                 x_image,
                                 exist,
-                                mirror_image_conv,
+                                periodic_image_conv,
                                 interaction_cluster[order]);
 
     }
@@ -1002,7 +1002,7 @@ void Cluster::set_interaction_cluster(const int order,
                                       const std::vector<int> *interaction_pair_in,
                                       const double *const *const *x_image,
                                       const int *exist,
-                                      const int mirror_image_conv,
+                                      const int periodic_image_conv,
                                       std::set<InteractionCluster> *interaction_cluster_out) const
 {
     //
@@ -1132,7 +1132,7 @@ void Cluster::set_interaction_cluster(const int order,
 
                     // Loop over the cell images of atom 'jat' and add to the list
                     // as a candidate for the cluster.
-                    // The mirror images whose distance is larger than the minimum value
+                    // The periodic images whose distance is larger than the minimum value
                     // of the distance(iat, jat) can be added to the cell_vector list.
                     for (const auto &it: distall[iat][jat]) {
                         if (exist[it.cell]) {
@@ -1186,14 +1186,14 @@ void Cluster::set_interaction_cluster(const int order,
                         // This combination is a candidate of the minimum distance cluster
                         distance_list.emplace_back(MinDistList(cellpair, dist_vector));
                     }
-                } // close loop over the mirror image combination
+                } // close loop over the periodic image combination
 
                 if (!distance_list.empty()) {
-                    // If the distance_list is not empty, there is a set of mirror images
+                    // If the distance_list is not empty, there is a set of periodic images
                     // that satisfies the condition of the cluster.
 
-                    if (mirror_image_conv == 0) {
-                        // assign IFCs to mirror images in which the center atom and each of the other atoms
+                    if (periodic_image_conv == 0) {
+                        // assign IFCs to periodic images in which the center atom and each of the other atoms
                         // are nearest.
                         // The distance between non-center atoms are not considered.
                         // The IFCs in this convention automatically satisfies the ASR without additional constraint, 
@@ -1234,13 +1234,13 @@ void Cluster::set_interaction_cluster(const int order,
                                                                              comb_cell_atom_center,
                                                                              distmax));
 
-                    } else/* if(mirror_image_conv == 1)*/{
+                    } else/* if(periodic_image_conv == 1)*/{
 
-                        // assign IFCs to mirror images in which the sum of the distances between the atom pairs 
+                        // assign IFCs to periodic images in which the sum of the distances between the atom pairs 
                         // is the smallest.
                         // The IFCs made in this convention satisfies the permutation symmetry.
                         // Additional constraints are imposed in constraint.cpp to make the IFCs satisfy ASR 
-                        // after assigning IFCs to the mirror images.
+                        // after assigning IFCs to the periodic images.
 
                         std::sort(distance_list.begin(), distance_list.end(), MinDistList::compare_sum_distance);
                         comb_cell_min.clear();

--- a/alm/cluster.h
+++ b/alm/cluster.h
@@ -260,7 +260,7 @@ public:
 
     void init(const System *system,
               const Symmetry *symmetry,
-              const int mirror_image_conv,
+              const int periodic_image_conv,
               const int verbosity,
               Timer *timer);
 
@@ -350,7 +350,7 @@ private:
                                    const std::vector<std::vector<int>> &map_p2s,
                                    const double *const *const *x_image,
                                    const int *exist,
-                                   const int mirror_image_conv) const;
+                                   const int periodic_image_conv) const;
 
     void set_interaction_cluster(const int order,
                                  const size_t natmin,
@@ -359,7 +359,7 @@ private:
                                  const std::vector<int> *interaction_pair_in,
                                  const double *const *const *x_image,
                                  const int *exist,
-                                 const int mirror_image_conv,
+                                 const int periodic_image_conv,
                                  std::set<InteractionCluster> *interaction_cluster_out) const;
 
     void cell_combination(const std::vector<std::vector<int>> &,

--- a/alm/constraint.cpp
+++ b/alm/constraint.cpp
@@ -1356,9 +1356,6 @@ void Constraint::get_constraint_translation_for_mirror_images(const Cell &superc
     const auto natmin = symmetry->get_nat_prim();
     const auto nat = supercell.number_of_atoms;
 
-    // generate combinations of mirror images
-    // long int n_mirror_images = nint(std::pow(static_cast<double>(27), order));
-
     unsigned int isize;
 
     std::vector<int> data;
@@ -1380,7 +1377,6 @@ void Constraint::get_constraint_translation_for_mirror_images(const Cell &superc
     allocate(ind, order + 2);
 
     // Create force constant table for search
-
     list_found.clear();
 
     for (const auto &p: fc_table) {
@@ -1475,7 +1471,6 @@ void Constraint::get_constraint_translation_for_mirror_images(const Cell &superc
                 long long int i_tmp, j_tmp, i_tmp2;
                 long int i_mi_tmp;
 
-                // consts_now_omp.resize(n_mirror_images, std::vector<double>(nparams));
 #ifdef _OPENMP
 #pragma omp for private(isize, ixyz, jcrd, j, jat, iter_found, loc_nonzero), nowait
 #endif
@@ -1494,12 +1489,6 @@ void Constraint::get_constraint_translation_for_mirror_images(const Cell &superc
                         for (jcrd = 0; jcrd < 3; ++jcrd) {
 
                             // Reset the temporary array for another constraint
-                            //for (j = 0; j < nparams; ++j) const_now_omp[j] = 0;
-                            // for (i_mirror_images = 0; i_mirror_images < n_mirror_images; i_mirror_images++) {
-                            //     for (j = 0; j < nparams; j++) {
-                            //         consts_now_omp[i_mirror_images][j] = 0.0;
-                            //     }
-                            // }
                             consts_now_omp.clear();
                             mirror_images_found.clear();
 
@@ -1551,7 +1540,6 @@ void Constraint::get_constraint_translation_for_mirror_images(const Cell &superc
                                         if (cluster_found == cluster->get_interaction_cluster(order, i).end()) {
                                             std::cout << "Warning: cluster corresponding to the IFC is NOT found.\n";
                                         } else {
-                                            // std::cout << "cluster corresponding to the IFC is found." << std::endl;
 
                                             // get weight
                                             weight = 1.0 / static_cast<double>((cluster_found->cell).size());
@@ -1577,8 +1565,6 @@ void Constraint::get_constraint_translation_for_mirror_images(const Cell &superc
                                                 }
 
                                                 // add to the constraint
-                                                // consts_now_omp[i_mirror_images][(*iter_found).mother] +=
-                                                //         weight * (*iter_found).sign;
                                                 consts_now_omp[i_mi_tmp][(*iter_found).mother] +=
                                                         weight * (*iter_found).sign;
                                             }
@@ -1589,7 +1575,6 @@ void Constraint::get_constraint_translation_for_mirror_images(const Cell &superc
                             } // close loop jat
 
                             // Add the constraint to the private array
-                            // for (i_mirror_images = 0; i_mirror_images < n_mirror_images; i_mirror_images++) {
                             for (i_mi_tmp = 0; i_mi_tmp < mirror_images_found.size(); i_mi_tmp++) {
                                 if (!is_allzero(consts_now_omp[i_mi_tmp], eps8, loc_nonzero, 0)) {
                                     if (consts_now_omp[i_mi_tmp][loc_nonzero] < 0) {

--- a/alm/constraint.cpp
+++ b/alm/constraint.cpp
@@ -1414,13 +1414,10 @@ void Constraint::get_constraint_translation_for_mirror_images(const Cell &superc
 
         // Generate atom pairs for each order
 
-        if (order == 0) continue;  // there is no new translational invariance
-
-        if (order > 2) {
-            // we assume that the cutoff radius is enough small
-            // for 5th or higher-order IFCs
-            continue;
-        } else {
+        if (order == 0) {
+            continue;  // there is no new translational invariance
+        }
+        else {
 
             // Anharmonic cases
 

--- a/alm/constraint.h
+++ b/alm/constraint.h
@@ -211,7 +211,7 @@ public:
                const Cluster *cluster,
                const Symmetry *symmetry,
                const int linear_model,
-               const int mirror_image_conv,
+               const int periodic_image_conv,
                const int verbosity,
                Timer *timer);
 
@@ -283,7 +283,7 @@ public:
                                   const Cluster *cluster,
                                   const Fcs *fcs,
                                   const int verbosity,
-                                  const int mirror_image_conv);
+                                  const int periodic_image_conv);
 
     bool ready_all_constraints() const;
 
@@ -387,7 +387,7 @@ private:
                                     ConstraintSparseForm &const_out,
                                     const bool do_rref = false) const;
 
-    void get_constraint_translation_for_mirror_images(const Cell &supercell,
+    void get_constraint_translation_for_periodic_images(const Cell &supercell,
                                                       const Symmetry *symmetry,
                                                       const Cluster *cluster,
                                                       const Fcs *fcs,

--- a/alm/input_parser.cpp
+++ b/alm/input_parser.cpp
@@ -690,7 +690,7 @@ void InputParser::parse_optimize_vars(ALM *alm)
             "L1_RATIO", "STANDARDIZE", "ENET_DNORM",
             "L1_ALPHA", "CV_MAXALPHA", "CV_MINALPHA", "CV_NALPHA",
             "CV", "MAXITER", "CONV_TOL", "NWRITE", "SOLUTION_PATH", "DEBIAS_OLS",
-            "MIRROR_IMAGE_CONV", "STOP_CRITERION"
+            "PERIODIC_IMAGE_CONV", "STOP_CRITERION"
     };
 
     std::map<std::string, std::string> optimize_var_dict;
@@ -785,8 +785,8 @@ void InputParser::parse_optimize_vars(ALM *alm)
     if (!optimize_var_dict["STOP_CRITERION"].empty()) {
         optcontrol.stop_criterion = boost::lexical_cast<int>(optimize_var_dict["STOP_CRITERION"]);
     }
-    if (!optimize_var_dict["MIRROR_IMAGE_CONV"].empty()) {
-        optcontrol.mirror_image_conv = boost::lexical_cast<int>(optimize_var_dict["MIRROR_IMAGE_CONV"]);
+    if (!optimize_var_dict["PERIODIC_IMAGE_CONV"].empty()) {
+        optcontrol.periodic_image_conv = boost::lexical_cast<int>(optimize_var_dict["PERIODIC_IMAGE_CONV"]);
     }
 
 

--- a/alm/optimize.h
+++ b/alm/optimize.h
@@ -73,7 +73,7 @@ public:
         num_l1_alpha = 50;
         save_solution_path = 0;
         stop_criterion = 5;
-        mirror_image_conv = 0;
+        mirror_image_conv = 1;
     }
 
     ~OptimizerControl() = default;

--- a/alm/optimize.h
+++ b/alm/optimize.h
@@ -50,8 +50,8 @@ public:
     // the solution path calculation stops when the validation error
     // increases for `stop_criterion` times consecutively.
 
-    // convention to assign IFCs to mirror images
-    int mirror_image_conv;
+    // convention to assign IFCs to periodic images
+    int periodic_image_conv;
 
 
     OptimizerControl()
@@ -73,7 +73,7 @@ public:
         num_l1_alpha = 50;
         save_solution_path = 0;
         stop_criterion = 5;
-        mirror_image_conv = 1;
+        periodic_image_conv = 1;
     }
 
     ~OptimizerControl() = default;

--- a/alm/writer.cpp
+++ b/alm/writer.cpp
@@ -120,7 +120,7 @@ void Writer::write_input_vars(const System *system,
         std::cout << "  SPARSESOLVER = " << optctrl.sparsesolver << '\n';
         std::cout << "  CONV_TOL = " << optctrl.tolerance_iteration << '\n';
         std::cout << "  MAXITER = " << optctrl.maxnum_iteration << "\n";
-        std::cout << "  MIRROR_IMAGE_CONV = " << optctrl.mirror_image_conv << "\n\n";
+        std::cout << "  PERIODIC_IMAGE_CONV = " << optctrl.periodic_image_conv << "\n\n";
         if (optctrl.linear_model == 2) {
             std::cout << " Elastic-net related variables:\n";
             std::cout << "  CV = " << std::setw(5) << optctrl.cross_validation << '\n';

--- a/anphon/dynamical.cpp
+++ b/anphon/dynamical.cpp
@@ -761,7 +761,7 @@ void Dynamical::calc_nonanalytic_k2(const double *xk_in,
                     std::complex<double> exp_phase_tmp = std::complex<double>(0.0, 0.0);
                     unsigned int atm_s2 = system->map_p2s[jat][i];
 
-                    // Average over mirror atoms
+                    // Average over periodic images
 
                     for (j = 0; j < mindist_list[iat][atm_s2].size(); ++j) {
                         unsigned int cell = mindist_list[iat][atm_s2][j];

--- a/anphon/gruneisen.cpp
+++ b/anphon/gruneisen.cpp
@@ -297,7 +297,7 @@ void Gruneisen::calc_dfc2_reciprocal(std::complex<double> **dphi2,
 
 void Gruneisen::prepare_delta_fcs(const std::vector<FcsArrayWithCell> &fcs_in,
                                   std::vector<FcsArrayWithCell> &delta_fcs,
-                                  const int mirror_image_mode) const
+                                  const int periodic_image_mode) const
 {
     unsigned int i, j;
     double vec[3], vec_origin[3];
@@ -321,11 +321,11 @@ void Gruneisen::prepare_delta_fcs(const std::vector<FcsArrayWithCell> &fcs_in,
     }
     std::sort(fcs_aligned.begin(), fcs_aligned.end());
 
-    if (mirror_image_mode == 0) {
+    if (periodic_image_mode == 0) {
         // original implementation
         // calculate IFC renormalization for the same atomic combination in the supercell
-        // but with different mirror images at once and assign the average value for each
-        // mirror images.
+        // but with different periodic images at once and assign the average value for each
+        // periodic images.
         index_old.clear();
         const auto nelems = 2 * (norder - 2) + 1;
         for (i = 0; i < nelems; ++i) index_old.push_back(-1);
@@ -430,9 +430,9 @@ void Gruneisen::prepare_delta_fcs(const std::vector<FcsArrayWithCell> &fcs_in,
                 delta_fcs.emplace_back(fcs_tmp, pairs_vec);
             }
         }
-    } else { // if(mirror_image_mode != 0)
+    } else { // if(periodic_image_mode != 0)
         // new implementation
-        // calculate IFC renormalization separately for each mirror image combinations.
+        // calculate IFC renormalization separately for each periodic image combinations.
         index_with_cell_old.clear();
         const auto nelems = 3 * (norder - 2) + 1;
         for (i = 0; i < nelems; ++i) index_with_cell_old.push_back(-1);

--- a/anphon/kpoint.cpp
+++ b/anphon/kpoint.cpp
@@ -397,7 +397,7 @@ void KpointMeshUniform::gen_kmesh(const std::vector<SymmetryOperation> &symmlist
                                   const bool time_reversal_symmetry)
 {
     // Generates the uniform grid points in the reciprocal space
-    // Search the mirror images that minimize |q+G|
+    // Search the periodic images that minimize |q+G|
     // TODO: save all q+G having the same Euclidean distance from origin for later use
 
     unsigned int ik;
@@ -445,26 +445,26 @@ void KpointMeshUniform::gen_kmesh(const std::vector<SymmetryOperation> &symmlist
         }
     }
 
-    Eigen::MatrixXd xkr_mirror(3, 27);
+    Eigen::MatrixXd xkr_periodic(3, 27);
     std::vector<double> distances(27);
     for (ik = 0; ik < nk; ++ik) {
         for (auto icell = 0; icell < 27; ++icell) {
             for (auto i = 0; i < 3; ++i) {
-                xkr_mirror(i, icell) = xkr[ik][i] + static_cast<double>(gvec_shift[icell][i]);
+                xkr_periodic(i, icell) = xkr[ik][i] + static_cast<double>(gvec_shift[icell][i]);
             }
         }
-        xkr_mirror = rlat * xkr_mirror;
+        xkr_periodic = rlat * xkr_periodic;
 
         std::vector<int> idx(27);
         std::iota(idx.begin(), idx.end(), 0);
 
         for (auto icell = 0; icell < 27; ++icell) {
-            auto norm = std::sqrt(xkr_mirror(0, icell) * xkr_mirror(0, icell)
-                                  + xkr_mirror(1, icell) * xkr_mirror(1, icell)
-                                  + xkr_mirror(2, icell) * xkr_mirror(2, icell));
+            auto norm = std::sqrt(xkr_periodic(0, icell) * xkr_periodic(0, icell)
+                                  + xkr_periodic(1, icell) * xkr_periodic(1, icell)
+                                  + xkr_periodic(2, icell) * xkr_periodic(2, icell));
             distances[icell] = norm;
         }
-        // find the mirror image having the minimum distance from (0, 0, 0)
+        // find the periodic image having the minimum distance from (0, 0, 0)
         std::stable_sort(idx.begin(), idx.end(),
                          [&distances](size_t i1, size_t i2) { return distances[i1] < distances[i2]; });
 
@@ -484,7 +484,7 @@ void KpointMeshUniform::gen_kmesh(const std::vector<SymmetryOperation> &symmlist
 //                << " " << gvec_shift[idx[icell]][1] << " " << gvec_shift[idx[icell]][2] << '\n';
 //            }
 //        }
-        // Select the first mirror image that gives the shortest |q+G|
+        // Select the first periodic image that gives the shortest |q+G|
         for (auto i = 0; i < 3; ++i) {
             xkr[ik][i] += static_cast<double>(gvec_shift[idx[0]][i]);
         }
@@ -513,9 +513,9 @@ void KpointMeshUniform::gen_kmesh_niggli(const std::vector<SymmetryOperation> &s
                                          const bool time_reversal_symmetry)
 {
     // Generates the uniform grid points in the reciprocal space
-    // Search the mirror images that minimize |q+G|.
+    // Search the periodic images that minimize |q+G|.
     // Niggli reduction is done for searching Gs that minimize |q+G| exhaustively
-    // from the centering cell and the surrounding 26 mirror images.
+    // from the centering cell and the surrounding 26 periodic images.
     // TODO: save all q+G having the same Euclidean distance from origin for later use
 
     unsigned int ik;
@@ -583,26 +583,26 @@ void KpointMeshUniform::gen_kmesh_niggli(const std::vector<SymmetryOperation> &s
     }
 
     // Find the G-vector that minimizes |q+G| in the reduced basis
-    Eigen::MatrixXd xkr_mirror(3, 27);
+    Eigen::MatrixXd xkr_periodic(3, 27);
     std::vector<double> distances(27);
     for (ik = 0; ik < nk; ++ik) {
         for (auto icell = 0; icell < 27; ++icell) {
             for (auto i = 0; i < 3; ++i) {
-                xkr_mirror(i, icell) = xkr(i, ik) + static_cast<double>(gvec_shift[icell][i]);
+                xkr_periodic(i, icell) = xkr(i, ik) + static_cast<double>(gvec_shift[icell][i]);
             }
         }
-        xkr_mirror = rlat_reduced * xkr_mirror;
+        xkr_periodic = rlat_reduced * xkr_periodic;
 
         std::vector<int> idx(27);
         std::iota(idx.begin(), idx.end(), 0);
 
         for (auto icell = 0; icell < 27; ++icell) {
-            auto norm = std::sqrt(xkr_mirror(0, icell) * xkr_mirror(0, icell)
-                                  + xkr_mirror(1, icell) * xkr_mirror(1, icell)
-                                  + xkr_mirror(2, icell) * xkr_mirror(2, icell));
+            auto norm = std::sqrt(xkr_periodic(0, icell) * xkr_periodic(0, icell)
+                                  + xkr_periodic(1, icell) * xkr_periodic(1, icell)
+                                  + xkr_periodic(2, icell) * xkr_periodic(2, icell));
             distances[icell] = norm;
         }
-        // find the mirror image having the minimum distance from (0, 0, 0)
+        // find the periodic image having the minimum distance from (0, 0, 0)
         std::stable_sort(idx.begin(), idx.end(),
                          [&distances](size_t i1, size_t i2) { return distances[i1] < distances[i2]; });
 

--- a/anphon/relaxation.cpp
+++ b/anphon/relaxation.cpp
@@ -2635,7 +2635,7 @@ void Relaxation::compute_del_v_strain_in_real_space1(const std::vector<FcsAligne
                                                      std::vector<FcsArrayWithCell> &delta_fcs,
                                                      const int ixyz1,
                                                      const int ixyz2,
-                                                     const int mirror_image_mode)
+                                                     const int periodic_image_mode)
 {
     unsigned int i, j;
     double vec[3], vec_origin[3];
@@ -2675,11 +2675,11 @@ void Relaxation::compute_del_v_strain_in_real_space1(const std::vector<FcsAligne
         }
     }
 
-    if (mirror_image_mode == 0) {
+    if (periodic_image_mode == 0) {
         // original implementation
         // calculate IFC renormalization for the same atomic combination in the supercell
-        // but with different mirror images at once and assign the average value for each
-        // mirror images.
+        // but with different periodic images at once and assign the average value for each
+        // periodic images.
         index_old.clear();
         const auto nelems = 2 * (norder - 2) + 1;
         for (i = 0; i < nelems; ++i) index_old.push_back(-1);
@@ -2790,9 +2790,9 @@ void Relaxation::compute_del_v_strain_in_real_space1(const std::vector<FcsAligne
                 delta_fcs.emplace_back(fcs_tmp, pairs_vec);
             }
         }
-    } else { // if(mirror_image_mode != 0)
+    } else { // if(periodic_image_mode != 0)
         // new implementation
-        // calculate IFC renormalization separately for each mirror image combinations.
+        // calculate IFC renormalization separately for each periodic image combinations.
         index_with_cell_old.clear();
         const auto nelems = 3 * (norder - 2) + 1;
         for (i = 0; i < nelems; ++i) index_with_cell_old.push_back(-1);
@@ -2892,15 +2892,15 @@ void Relaxation::compute_del_v_strain_in_real_space1(const std::vector<FcsAligne
     set_index_uniq.clear();
 }
 
-// mirror_image_mode = 1 is used.
-// mirror_image_mode = 0 has not been thoroughly tested.
+// periodic_image_mode = 1 is used.
+// periodic_image_mode = 0 has not been thoroughly tested.
 void Relaxation::compute_del_v_strain_in_real_space2(const std::vector<FcsAlignedForGruneisen> &fcs_aligned,
                                                      std::vector<FcsArrayWithCell> &delta_fcs,
                                                      const int ixyz11,
                                                      const int ixyz12,
                                                      const int ixyz21,
                                                      const int ixyz22,
-                                                     const int mirror_image_mode)
+                                                     const int periodic_image_mode)
 {
     unsigned int i, j;
     double vec1[3], vec2[3], vec_origin[3];
@@ -2940,11 +2940,11 @@ void Relaxation::compute_del_v_strain_in_real_space2(const std::vector<FcsAligne
         }
     }
 
-    if (mirror_image_mode == 0) {
+    if (periodic_image_mode == 0) {
         // original implementation
         // calculate IFC renormalization for the same atomic combination in the supercell
-        // but with different mirror images at once and assign the average value for each
-        // mirror images.
+        // but with different periodic images at once and assign the average value for each
+        // periodic images.
         index_old.clear();
         const auto nelems = 2 * (norder - 3) + 1;
         for (i = 0; i < nelems; ++i) index_old.push_back(-1);
@@ -3062,9 +3062,9 @@ void Relaxation::compute_del_v_strain_in_real_space2(const std::vector<FcsAligne
                 delta_fcs.emplace_back(fcs_tmp, pairs_vec);
             }
         }
-    } else { // if(mirror_image_mode != 0)
+    } else { // if(periodic_image_mode != 0)
         // new implementation
-        // calculate IFC renormalization separately for each mirror image combinations.
+        // calculate IFC renormalization separately for each periodic image combinations.
         index_with_cell_old.clear();
         const auto nelems = 3 * (norder - 3) + 1;
         for (i = 0; i < nelems; ++i) index_with_cell_old.push_back(-1);

--- a/anphon/relaxation.h
+++ b/anphon/relaxation.h
@@ -279,7 +279,7 @@ private:
                                              std::vector<FcsArrayWithCell> &delta_fcs,
                                              const int ixyz1,
                                              const int ixyz2,
-                                             const int mirror_image_mode);
+                                             const int periodic_image_mode);
 
     void compute_del_v_strain_in_real_space2(const std::vector<FcsAlignedForGruneisen> &,
                                              std::vector<FcsArrayWithCell> &,

--- a/docs/source/almdir/inputalm.rst
+++ b/docs/source/almdir/inputalm.rst
@@ -59,8 +59,8 @@ List of supported input variables
    :ref:`DFSET <alm_dfset>`, :ref:`DFSET_CV <alm_dfset_cv>`, :ref:`ENET_DNORM <alm_enet_dnorm>`, :ref:`FC2XML <alm_fc2xml>`, :ref:`FC3XML <alm_fc3xml>`
    :ref:`ICONST <alm_iconst>`, :ref:`L1_ALPHA <alm_l1_alpha>`, :ref:`L1_RATIO <alm_l1_ratio>`, :ref:`LMODEL <alm_lmodel>`
    :ref:`MAXITER <alm_maxiter>`, :ref:`NDATA <alm_ndata>`, :ref:`NDATA_CV <alm_ndata_cv>`, :ref:`NSTART NEND <alm_nstart>`, :ref:`NSTART_CV NEND_CV <alm_nstart_cv>`
-   :ref:`ROTAXIS <alm_rotaxis>`, :ref:`SKIP <alm_skip>`, :ref:`SOLUTION_PATH <alm_solution_path>`, :ref:`SPARSE <alm_sparse>`, :ref:`SPARSESOLVER <alm_sparsesolver>`
-   :ref:`STANDARDIZE <alm_standardize>`, :ref:`STOP_CRITERION <alm_stop_criterion>`
+   :ref:`ROTAXIS <alm_rotaxis>`, :ref:`MIRROR_IMAGE_CONV<alm_mirror_image_conv>`, :ref:`SKIP <alm_skip>`, :ref:`SOLUTION_PATH <alm_solution_path>`, :ref:`SPARSE <alm_sparse>`
+   :ref:`SPARSESOLVER <alm_sparsesolver>`, :ref:`STANDARDIZE <alm_standardize>`, :ref:`STOP_CRITERION <alm_stop_criterion>`
 
 
 Description of input variables
@@ -503,6 +503,23 @@ This field is necessary when ``MODE = optimize``.
  :Default: 11
  :Type: Integer
  :Description: See :ref:`this page<constraint_IFC>` for the numerical formulae.
+
+````
+
+.. _alm_mirror_image_conv: 
+
+* MIRROR_IMAGE_CONV-tag = 0 | 1
+
+ ===== =============================================================================================
+   0    Impose the constraints on IFCs (acoustic sum rule) in the considering supercell.
+   1    | Consider the periodic images when generating the constraints.
+        | The resultant IFCs simultaneously satisfy the permutation symmetry, ASR, 
+        | and the space group symmetry in the infinite space.
+        | For more details, please see Appendix D of the `original paper <https://arxiv.org/abs/2205.08789>`_.
+ ===== =============================================================================================
+
+ :Default: 1
+ :Type: Integer
 
 ````
 

--- a/docs/source/almdir/inputalm.rst
+++ b/docs/source/almdir/inputalm.rst
@@ -59,7 +59,7 @@ List of supported input variables
    :ref:`DFSET <alm_dfset>`, :ref:`DFSET_CV <alm_dfset_cv>`, :ref:`ENET_DNORM <alm_enet_dnorm>`, :ref:`FC2XML <alm_fc2xml>`, :ref:`FC3XML <alm_fc3xml>`
    :ref:`ICONST <alm_iconst>`, :ref:`L1_ALPHA <alm_l1_alpha>`, :ref:`L1_RATIO <alm_l1_ratio>`, :ref:`LMODEL <alm_lmodel>`
    :ref:`MAXITER <alm_maxiter>`, :ref:`NDATA <alm_ndata>`, :ref:`NDATA_CV <alm_ndata_cv>`, :ref:`NSTART NEND <alm_nstart>`, :ref:`NSTART_CV NEND_CV <alm_nstart_cv>`
-   :ref:`ROTAXIS <alm_rotaxis>`, :ref:`MIRROR_IMAGE_CONV<alm_mirror_image_conv>`, :ref:`SKIP <alm_skip>`, :ref:`SOLUTION_PATH <alm_solution_path>`, :ref:`SPARSE <alm_sparse>`
+   :ref:`PERIODIC_IMAGE_CONV<alm_periodic_image_conv>`, :ref:`ROTAXIS <alm_rotaxis>`, :ref:`SKIP <alm_skip>`, :ref:`SOLUTION_PATH <alm_solution_path>`, :ref:`SPARSE <alm_sparse>`
    :ref:`SPARSESOLVER <alm_sparsesolver>`, :ref:`STANDARDIZE <alm_standardize>`, :ref:`STOP_CRITERION <alm_stop_criterion>`
 
 
@@ -506,9 +506,9 @@ This field is necessary when ``MODE = optimize``.
 
 ````
 
-.. _alm_mirror_image_conv: 
+.. _alm_periodic_image_conv: 
 
-* MIRROR_IMAGE_CONV-tag = 0 | 1
+* PERIODIC_IMAGE_CONV-tag = 0 | 1
 
  ===== =============================================================================================
    0    Impose the constraints on IFCs (acoustic sum rule) in the considering supercell.
@@ -516,6 +516,7 @@ This field is necessary when ``MODE = optimize``.
         | The resultant IFCs simultaneously satisfy the permutation symmetry, ASR, 
         | and the space group symmetry in the infinite space.
         | For more details, please see Appendix D of the `original paper <https://arxiv.org/abs/2205.08789>`_.
+        | (Note that we use the term "mirror image" instead of "periodic image" in the paper.) 
  ===== =============================================================================================
 
  :Default: 1

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -101,7 +101,7 @@ Please cite the following article when you use ALAMODE:
     * - [3]_
       - Anharmonic free energies within SCP or improved SCP (ISC)
     * - [4]_
-      - SCP-based structural optimization or ``MIRROR_IMAGE_CONV = 1`` in the **alm** code
+      - SCP-based structural optimization or ``MIRROR_IMAGE_CONV = 1`` (default) in the **alm** code
     * - [5]_
       - QHA-based structural optimization
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -101,7 +101,7 @@ Please cite the following article when you use ALAMODE:
     * - [3]_
       - Anharmonic free energies within SCP or improved SCP (ISC)
     * - [4]_
-      - SCP-based structural optimization or ``MIRROR_IMAGE_CONV = 1`` (default) in the **alm** code
+      - SCP-based structural optimization or ``PERIODIC_IMAGE_CONV = 1`` (default) in the **alm** code
     * - [5]_
       - QHA-based structural optimization
 


### PR DESCRIPTION
Optimized the memory usage in generating the constraints when ``PERIODIC_IMAGE_CONV=1``.

I have changed the implementation of ``Constraint::get_constraint_translation_for_periodic_images`` to allocate memory only for the necessary periodic images, while the memory was allocated for all possible periodic images in the original implementation.
This change in the implementation lead to a speedup of the code, and the execution time of ``PERIODIC_IMAGE_CONV=1`` is now comparable to that of ``PERIODIC_IMAGE_CONV=0``.

